### PR TITLE
Introduce output element which renders into separate window

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Depending on whether or not a bundler / preprocessor is used, the way how custom
 </html>
 ```
 
-In order to use the elements, place a `<textarea>` (input) and one or more `<carnet-display>` / `<iframe>` elements (outputs) into a `<carnet-sketch>` container. Markup from the `<textarea>` is then automatically mirrored into a shadow DOM (`<carnet-display>` outputs) or a nested browser context (`<iframe>` outputs). The outputs are refreshed whenever the input changes.
+In order to use the elements, place a `<textarea>` (input) and one or more `<carnet-display>`, `<carnet-window>` or `<iframe>` elements (outputs) into a `<carnet-sketch>` container. Markup from the `<textarea>` is then automatically mirrored into a shadow DOM (`<carnet-display>` outputs), a separate browser window (`<carnet-window` outputs) or a nested browser context (`<iframe>` outputs). The outputs are refreshed whenever the input changes.
 
 **Example**:
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 import { CarnetDisplay } from './src/carnet-display.js';
 import { CarnetSketch } from './src/carnet-sketch.js';
+import { CarnetWindow } from './src/carnet-window.js';
 
 customElements.define(CarnetDisplay.is, CarnetDisplay);
 customElements.define(CarnetSketch.is, CarnetSketch);
+customElements.define(CarnetWindow.is, CarnetWindow);

--- a/sample/blank.html
+++ b/sample/blank.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <script type="module" src="../index.js"></script>
+    </head>
+    <body>
+        <carnet-display></carnet-display>
+    </body>
+</html>

--- a/sample/index.html
+++ b/sample/index.html
@@ -64,6 +64,16 @@
                 background-color: #333;
             }
 
+            carnet-sketch output a.carnet-window,
+            carnet-sketch output a.carnet-window:link {
+                border: 1px solid #333;
+                padding: calc(1/8 * 1em);
+                background-color: white;
+                color: inherit;
+                display: block;
+                text-decoration: underline;
+            }
+
             carnet-sketch carnet-display, carnet-sketch iframe {
                 background-color: white;
                 border: 1rem solid white;
@@ -80,6 +90,17 @@
                 margin: 1rem auto;
             }
         </style>
+        <script>
+            document.addEventListener('DOMContentLoaded', () => {
+                let w = document.createElement('carnet-window');
+                w.url = document.location.toString().replace('index.html', 'blank.html');
+                document.querySelectorAll('a.carnet-window').forEach((link) => {
+                    link.addEventListener('click', () => {
+                        link.parentElement.appendChild(w);
+                    });
+                });
+            });
+        </script>
     </head>
     <body>
         <main>
@@ -110,6 +131,7 @@
 </textarea>
 
                 <output>
+                    <a class="carnet-window">Open in Separate Window</a>
                     <carnet-display></carnet-display>
                 </output>
             </carnet-sketch>
@@ -130,6 +152,7 @@
 </textarea>
 
                 <output>
+                    <a class="carnet-window">Open in Separate Window</a>
                     <iframe></iframe>
                 </output>
             </carnet-sketch>

--- a/src/blank.html
+++ b/src/blank.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+    </head>
+    <body>
+        <carnet-blank></carnet-blank>
+    </body>
+</html>

--- a/src/carnet-sketch.js
+++ b/src/carnet-sketch.js
@@ -31,7 +31,7 @@ class CarnetSketch extends HTMLElement {
       this._markupMirror.inputDisconnect();
     }
 
-    const outputs = this.querySelectorAll('carnet-display, iframe');
+    const outputs = this.querySelectorAll('carnet-display, carnet-window, iframe');
     this._markupMirror.outputsSet(outputs);
   }
 

--- a/src/carnet-window.js
+++ b/src/carnet-window.js
@@ -1,0 +1,97 @@
+class CarnetWindow extends HTMLElement {
+  static get is() {
+    return 'carnet-window';
+  }
+
+  static get boundAttributes() {
+    return ['srcdoc', 'url', 'name'];
+  }
+
+  attributeChangedCallback(attrName, oldValue, newValue) {
+    if (attrName === 'srcdoc') {
+      this.srcdoc = newValue;
+    }
+    else if (attrName === 'name') {
+      this.name = newValue;
+    }
+    else if (attrName === 'url') {
+      this.url = newValue;
+    }
+  }
+
+  get srcdoc() {
+    return this._srcdoc;
+  }
+
+  set srcdoc(srcdoc) {
+    this._srcdoc = srcdoc;
+    this._windowRefresh();
+  }
+
+  get name() {
+    return this._name;
+  }
+
+  set name(name) {
+    this._name = name;
+    this._windowRefresh();
+  }
+
+  get url() {
+    return this._url;
+  }
+
+  set url(url) {
+    this._url = url;
+    this._windowRefresh();
+  }
+
+  constructor() {
+    super();
+    this._name = "Carnet Preview"
+    this._srcdoc = "";
+    this._url = "about:blank";
+    this._window = null;
+    this._connected = false;
+  }
+
+  connectedCallback() {
+    this._connected = true;
+    this._windowRefresh();
+  }
+
+  disconnectedCallback() {
+    this._connected = false;
+  }
+
+  _windowRefresh() {
+    if (this._connected) {
+      if (this._window === null || this._window.closed) {
+        this._window = window.open(this._url, this._name);
+        this._window.addEventListener('DOMContentLoaded', () => this._windowRefresh());
+        return;
+      }
+
+      let child = this._window;
+      if (child.location.toString() !== this._url) {
+        child.location.replace(this._url);
+        this._window.addEventListener('DOMContentLoaded', () => this._windowRefresh());
+        return;
+      }
+
+      if (child.name !== this._name) {
+        child.name = this._name;
+      }
+
+      const display = child.document.querySelector('carnet-display');
+      if (display) {
+        display.srcdoc = this._srcdoc;
+      }
+      else {
+        child.document.body.innerHTML = this._srcdoc;
+      }
+    }
+  }
+}
+
+export { CarnetWindow };


### PR DESCRIPTION
Introduce the `<carnet-window>` custom element. If placed inside a `<carnet-sketch>`, markup is rendered into a separate window. The content is either placed inside a `<carnet-display>` (if present in the destination document) or assigned to `document.body.innerHTML`.

The element provides the following attributes:

**srcdoc:** Source markup representing the windows content
**url:** Url of the document to be loaded (defaults to `about:blank`).
**name:** Name of the window. An existing window with the same name will be reused.
