### PR TITLE
Allow to load markup source from external document

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,18 @@ In order to use the elements, place a `<textarea>` (input) and one or more `<car
 </carnet-sketch>
 ```
 
+Example markup code can be placed in external files and then referenced using a `<link>` element placed inside a `<carnet-sketch>`. The `rel` attribute of the `link` needs to be set to `CARNET.source`. The markup source is then loaded automatically from the referenced document and placed into the `<textarea>`.
+
+**Example**:
+
+```html
+<carnet-sketch>
+    <link rel="CARNET.sketch" href="./some-example.html">
+    <textarea></textarea>
+    <carnet-display></carnet-display>
+</carnet-sketch>
+```
+
 ### License
 
 MIT

--- a/sample/external.css
+++ b/sample/external.css
@@ -1,0 +1,6 @@
+    h1 {
+        color: cyan;
+    }
+    p {
+        color: magenta;
+    }

--- a/sample/external.html
+++ b/sample/external.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+    </head>
+    <body>
+
+<link rel="stylesheet" href="./external.css">
+<h1>External document</h1>
+<p>This document was loaded from an external resource.</p>
+
+    </body>
+</html>

--- a/sample/index.html
+++ b/sample/index.html
@@ -156,6 +156,23 @@
                     <iframe></iframe>
                 </output>
             </carnet-sketch>
+
+            <h2>Load from external document</h2>
+            <p>
+                Markup source can be loaded from an external document using a
+                <code>&lt;link&gt;</code> tag. The <code>rel</code> attribute
+                must be set to <code>CARNET.source</code>.
+            </p>
+
+            <carnet-sketch>
+                <link rel="CARNET.source" href="./external.html">
+                <textarea></textarea>
+
+                <output>
+                    <a class="carnet-window">Open in Separate Window</a>
+                    <carnet-display></carnet-display>
+                </output>
+            </carnet-sketch>
         </main>
     </body>
 </html>

--- a/src/carnet-sketch.js
+++ b/src/carnet-sketch.js
@@ -22,8 +22,34 @@ class CarnetSketch extends HTMLElement {
     this.markupMirrorDisconnect();
   }
 
+  markupSourceLoad() {
+    const source = this.querySelector('link[rel="CARNET.source"]');
+    if (source && source.href) {
+      fetch(source.href).then((response) => {
+        if (response.ok) {
+          response.text().then((text) => {
+            const parser = new DOMParser();
+            const doc = parser.parseFromString(text, "text/html");
+            this._initialMarkup = doc.body.innerHTML;
+            this.markupSourceInitialize();
+          });
+        }
+      });
+    }
+  }
+
+  markupSourceInitialize() {
+    const area = this.querySelector('textarea');
+    if (area !== null) {
+      area.value = this._initialMarkup;
+      area.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+  }
+
   markupMirrorConnect() {
     const area = this.querySelector('textarea');
+    this.markupSourceLoad();
+
     if (area !== null) {
       this._markupMirror.inputConnect(area);
     }

--- a/src/carnet-window.js
+++ b/src/carnet-window.js
@@ -48,7 +48,7 @@ class CarnetWindow extends HTMLElement {
 
   constructor() {
     super();
-    this._name = "Carnet Preview"
+    this._name = "Carnet Preview";
     this._srcdoc = "";
     this._url = "about:blank";
     this._window = null;


### PR DESCRIPTION
In order to avoid clutter inside `<carnet-sketch>`, it is desirable to reference external documents to be used as the markup source.

Note: The parcel bundler automatically follows the `href` property of `link` elements. Thus, let's just use that element with a custom `rel="CARNET.source"` attribute. See also [this overview](http://microformats.org/wiki/existing-rel-values) of existing `rel` values.