### PR TITLE
Add support for codemirror editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,12 @@
         "glob": "^7.1.1"
       }
     },
+    "codemirror": {
+      "version": "5.49.2",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.49.2.tgz",
+      "integrity": "sha512-dwJ2HRPHm8w51WB5YTF9J7m6Z5dtkqbU9ntMZ1dqXyFB9IpjoUFDj80ahRVEoVanfIp6pfASJbOlbWdEf8FOzQ==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "author": "Lorenz Schori",
   "license": "MIT",
   "devDependencies": {
+    "codemirror": "^5.49.2",
     "jshint": "^2.10.2"
   }
 }

--- a/sample/index.html
+++ b/sample/index.html
@@ -4,6 +4,7 @@
         <title>Carnet Sketch Custom Element Demo</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <script type="module" src="../index.js"></script>
+        <link rel="stylesheet" href="../node_modules/codemirror/lib/codemirror.css">
         <style>
             *, *:before, *:after {
               box-sizing: inherit;
@@ -244,6 +245,52 @@ p {
                     <carnet-display></carnet-display>
                 </output>
             </carnet-sketch>
+
+            <h2>Codemirror editor</h2>
+            <p>
+                A <code>&lt;carnet-editor&gt;</code> element can contain a
+                codemirror instance.
+            </p>
+
+            <p><small>Note: Markup is editable</small></p>
+
+
+            <carnet-sketch>
+
+<carnet-source><template><link rel="stylesheet" href="./fragment.css">
+<h1>Inside shadow DOM</h1>
+<p>This markup fragment is rendered inside a shadow DOM. Note that the linked CSS does not affect the whole page, but only this isolated fragment.</p>
+  </template></carnet-source>
+
+                <carnet-editor class="carnet-codemirror"></carnet-editor>
+
+                <output>
+                    <a class="carnet-window">Open in Separate Window</a>
+                    <carnet-display></carnet-display>
+                </output>
+            </carnet-sketch>
         </main>
+
+        <script src="../node_modules/codemirror/lib/codemirror.js"></script>
+        <script src="../node_modules/codemirror/addon/edit/closetag.js"></script>
+        <script src="../node_modules/codemirror/addon/fold/xml-fold.js"></script>
+        <script src="../node_modules/codemirror/mode/xml/xml.js"></script>
+        <script src="../node_modules/codemirror/mode/javascript/javascript.js"></script>
+        <script src="../node_modules/codemirror/mode/css/css.js"></script>
+        <script src="../node_modules/codemirror/mode/htmlmixed/htmlmixed.js"></script>
+        <script>
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.carnet-codemirror').forEach( (element) => {
+    console.log(element);
+        CodeMirror(element, {
+            autoCloseTags: true,
+            indentUnit: 4,
+            inputStyle: "contenteditable",
+            lineNumbers: true,
+            mode: "text/html"
+        });
+  });
+});
+        </script>
     </body>
 </html>

--- a/sample/index.html
+++ b/sample/index.html
@@ -4,7 +4,6 @@
         <title>Carnet Sketch Custom Element Demo</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <script type="module" src="../index.js"></script>
-        <link rel="stylesheet" href="../node_modules/codemirror/lib/codemirror.css">
         <style>
             *, *:before, *:after {
               box-sizing: inherit;
@@ -59,6 +58,10 @@
                 height: auto;
                 min-height: 10rem;
                 padding: 0.5rem;
+            }
+
+            carnet-sketch .CodeMirror {
+                border: 1px solid #333;
             }
 
             carnet-sketch output {
@@ -271,26 +274,46 @@ p {
             </carnet-sketch>
         </main>
 
-        <script src="../node_modules/codemirror/lib/codemirror.js"></script>
-        <script src="../node_modules/codemirror/addon/edit/closetag.js"></script>
-        <script src="../node_modules/codemirror/addon/fold/xml-fold.js"></script>
-        <script src="../node_modules/codemirror/mode/xml/xml.js"></script>
-        <script src="../node_modules/codemirror/mode/javascript/javascript.js"></script>
-        <script src="../node_modules/codemirror/mode/css/css.js"></script>
-        <script src="../node_modules/codemirror/mode/htmlmixed/htmlmixed.js"></script>
+        <!-- Load codemirror either from local copy (node modules) or CDN -->
+
+        <!--
+            <script src="../node_modules/codemirror/lib/codemirror.js"></script>
+            <script src="../node_modules/codemirror/addon/edit/closetag.js"></script>
+            <script src="../node_modules/codemirror/addon/fold/xml-fold.js"></script>
+            <script src="../node_modules/codemirror/mode/xml/xml.js"></script>
+            <script src="../node_modules/codemirror/mode/javascript/javascript.js"></script>
+            <script src="../node_modules/codemirror/mode/css/css.js"></script>
+            <script src="../node_modules/codemirror/mode/htmlmixed/htmlmixed.js"></script>
+            <link  href="../node_modules/codemirror/lib/codemirror.css" rel="stylesheet">
+        -->
+
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/codemirror.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/addon/edit/closetag.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/addon/fold/xml-fold.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/mode/xml/xml.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/mode/javascript/javascript.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/mode/css/css.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/mode/htmlmixed/htmlmixed.js"></script>
+        <link  href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/codemirror.css" rel="stylesheet">
         <script>
+
 document.addEventListener('DOMContentLoaded', () => {
-  document.querySelectorAll('.carnet-codemirror').forEach( (element) => {
-    console.log(element);
-        CodeMirror(element, {
-            autoCloseTags: true,
-            indentUnit: 4,
-            inputStyle: "contenteditable",
-            lineNumbers: true,
-            mode: "text/html"
-        });
-  });
+    document.querySelectorAll('.carnet-codemirror').forEach( (element) => {
+        if (typeof CodeMirror !== 'undefined') {
+            CodeMirror(element, {
+                autoCloseTags: true,
+                indentUnit: 4,
+                inputStyle: "contenteditable",
+                lineNumbers: true,
+                mode: "text/html"
+            });
+        }
+        else {
+            element.innerHTML = '<pre>Failed to load codemirror</pre>'
+        }
+    });
 });
+
         </script>
     </body>
 </html>

--- a/src/codemirror-adapter.js
+++ b/src/codemirror-adapter.js
@@ -12,7 +12,7 @@ export class CodeMirrorAdapter {
 
     const current = this._codemirror.getValue();
     const update = (name, previous, current) => {
-      if (current !== null) {
+      if (current !== null && this._codemirror.getValue() !== current) {
         this._codemirror.setValue(current);
       }
     };

--- a/src/codemirror-adapter.js
+++ b/src/codemirror-adapter.js
@@ -1,0 +1,31 @@
+export class CodeMirrorAdapter {
+  constructor() {
+    this._codemirror = null;
+    this._callback = null;
+  }
+
+  connect(element, callback) {
+    this._callback = (instance, change) => callback(instance.getValue());
+
+    this._codemirror = element.CodeMirror;
+    this._codemirror.on('change', this._callback);
+
+    const current = this._codemirror.getValue();
+    const update = (name, previous, current) => {
+      if (current !== null) {
+        this._codemirror.setValue(current);
+      }
+    };
+
+    return {
+      current,
+      update
+    }
+  }
+
+  disconnect() {
+    this._codemirror.off('change', this._callback);
+    this._codemirror = null;
+    this._callback = null;
+  }
+}

--- a/src/textarea-adapter.js
+++ b/src/textarea-adapter.js
@@ -1,0 +1,31 @@
+export class TextareaAdapter {
+  constructor() {
+    this._element = null;
+    this._callback = null;
+  }
+
+  connect(element, callback) {
+    this._callback = (evt) => callback(evt.target.value);
+
+    this._element = element;
+    this._element.addEventListener('input', this._callback);
+
+    const current = element.value;
+    const update = (name, previous, current) => {
+      if (current !== null) {
+        this._element.value = current;
+      }
+    };
+
+    return {
+      current,
+      update
+    }
+  }
+
+  disconnect() {
+    this._element.removeEventListener('input', this._callback);
+    this._element = null;
+    this._callback = null;
+  }
+}


### PR DESCRIPTION
If a codemirror instance is found inside a `<carnet-editor>` element, connect that to all outputs of the enclosing `<carnet-sketch>`.